### PR TITLE
PDU: Fix message concatenation

### DIFF
--- a/gsmmodem/pdu.py
+++ b/gsmmodem/pdu.py
@@ -24,6 +24,7 @@ else: #pragma: no cover
     toByteArray = lambda x: bytearray(x.decode('hex')) if type(x) in (str, unicode) else x
     rawStrToByteArray = bytearray
 
+TEXT_MODE = ('\n\r !\"#%&\'()*+,-./0123456789:;<=>?ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz') # TODO: Check if all of them are supported inside text mode
 # Tables can be found at: http://en.wikipedia.org/wiki/GSM_03.38#GSM_7_bit_default_alphabet_and_extension_table_of_3GPP_TS_23.038_.2F_GSM_03.38
 GSM7_BASIC = ('@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1bÆæßÉ !\"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ`¿abcdefghijklmnopqrstuvwxyzäöñüà')
 GSM7_EXTENDED = {chr(0xFF): 0x0A,
@@ -688,10 +689,10 @@ def encodeTextMode(plaintext):
     if PYTHON_VERSION >= 3:
         plaintext = str(plaintext)
     for char in plaintext:
-        idx = GSM7_BASIC.find(char)
+        idx = TEXT_MODE.find(char)
         if idx != -1:
             continue
-        elif not discardInvalid:
+        else:
             raise ValueError('Cannot encode char "{0}" inside text mode'.format(char))
 
     if len(plaintext) > MAX_MESSAGE_LENGTH[0x00]:

--- a/gsmmodem/pdu.py
+++ b/gsmmodem/pdu.py
@@ -673,6 +673,32 @@ def decodeSemiOctets(encodedNumber, numberOfOctets=None):
                 break
     return ''.join(number)
 
+def encodeTextMode(plaintext):
+    """ Text mode checker
+
+    Tests whther SMS could be sent in text mode
+
+    :param text: the text string to encode
+
+    :raise ValueError: if the text string cannot be sent in text mode
+
+    :return: Passed string
+    :rtype: str
+    """
+    if PYTHON_VERSION >= 3:
+        plaintext = str(plaintext)
+    for char in plaintext:
+        idx = GSM7_BASIC.find(char)
+        if idx != -1:
+            continue
+        elif not discardInvalid:
+            raise ValueError('Cannot encode char "{0}" inside text mode'.format(char))
+
+    if len(plaintext) > MAX_MESSAGE_LENGTH[0x00]:
+        raise ValueError('Massage is too long for inside text mode (maximum {0} characters)'.format(MAX_MESSAGE_LENGTH[0x00]))
+
+    return plaintext
+
 def encodeGsm7(plaintext, discardInvalid=False):
     """ GSM-7 text encoding algorithm
 

--- a/test/fakemodems.py
+++ b/test/fakemodems.py
@@ -99,7 +99,8 @@ class GenericTestModem(FakeModem):
                           'AT+WIND?\r': ['ERROR\r\n'],
                           'AT+WIND=50\r': ['ERROR\r\n'],
                           'AT+ZPAS?\r': ['ERROR\r\n'],
-                          'AT+CPIN?\r': ['+CPIN: READY\r\n', 'OK\r\n']} 
+                          'AT+CSCS=?\r': ['+CSCS: ("GSM",UCS2")\r\n', 'OK\r\n'],
+                          'AT+CPIN?\r': ['+CPIN: READY\r\n', 'OK\r\n']}
 
     def getResponse(self, cmd):
         if not self._pinLock and cmd == 'AT+CLCC\r':

--- a/test/test_pdu.py
+++ b/test/test_pdu.py
@@ -493,6 +493,33 @@ class TestSmsPdu(unittest.TestCase):
         pdu = 'AEFDSDFSDFSDFS'
         self.assertRaises(gsmmodem.exceptions.EncodingError, gsmmodem.pdu.decodeSmsPdu, pdu)
 
+    def test_encode_Gsm7_divideSMS(self):
+        """ Tests whether text will be devided into a correct number of chunks while using GSM-7 alphabet"""
+        text = "12345-010 12345-020 12345-030 12345-040 12345-050 12345-060"
+        self.assertEqual(len(gsmmodem.pdu.divideTextGsm7(text)), 1)
+        text = "12345-010 12345-020 12345-030 12345-040 12345-050 12345-060 12345-070 12345-080 12345-090 12345-100 12345-010 12345-020 12345-030 12345-040 12345-050 123"
+        self.assertEqual(len(gsmmodem.pdu.divideTextGsm7(text)), 1)
+        text = "12345-010 12345-020 12345-030 12345-040 12345-050 12345-060 12345-070 12345-080 12345-090 12345-100 12345-010 12345-020 12345-030 12345-040 12345-050 1234"
+        self.assertEqual(len(gsmmodem.pdu.divideTextGsm7(text)), 2)
+        text = "12345-010 12345-020 12345-030 12345-040 12345-050 12345-060 12345-070 12345-080 12345-090 12345-100 12345-010 12345-020 12345-030 12345-040 12345-050 12]"
+        self.assertEqual(len(gsmmodem.pdu.divideTextGsm7(text)), 2)
+        text = "12345-010,12345-020,12345-030,12345-040,12345-050,12345-060,12345-070,12345-080,12345-090,12345-100,12345-110,12345-120,12345-130,12345-140,12345-150,[[[[[[[["
+        self.assertEqual(len(gsmmodem.pdu.divideTextGsm7(text)), 2)
+
+    def test_encode_Ucs2_divideSMS(self):
+        """ Tests whether text will be devided into a correct number of chunks while using UCS-2 alphabet"""
+        text = "12345-010 12345-020 12345-030 12345-040 12345-050 12345-060"
+        self.assertEqual(len(gsmmodem.pdu.divideTextUcs2(text)), 1)
+        text = "12345-010 12345-020 12345-030 12345-040 12345-050 12345-060 1234567"
+        self.assertEqual(len(gsmmodem.pdu.divideTextUcs2(text)), 1)
+        text = "12345-010 12345-020 12345-030 12345-040 12345-050 12345-060 12345678"
+        self.assertEqual(len(gsmmodem.pdu.divideTextUcs2(text)), 2)
+        text = "12345-010 12345-020 12345-030 12345-040 12345-050 12345-060 123456["
+        self.assertEqual(len(gsmmodem.pdu.divideTextUcs2(text)), 1)
+        text = "12345-010 12345-020 12345-030 12345-040 12345-050 12345-060 1234567["
+        self.assertEqual(len(gsmmodem.pdu.divideTextUcs2(text)), 2)
+        text = "12345-010,12345-020,12345-030,12345-040,12345-050,12345-060,123456 12345-010,12345-020,12345-030,12345-040,12345-050,12345-060,1234567"
+        self.assertEqual(len(gsmmodem.pdu.divideTextUcs2(text)), 2)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Trying to resolve #4 . I provided unit tests for new dividing methods, but do not have an opportunity to test it on real hardware.

Few notes:
 - Now modem is forced to work in text mode, because handling non-ASCII characters inside text mode may lead to errors (such as GSM-7 escape character).
 - Chunk calculation requires redundant encoding, because escaped symbols (2-byte long) cannot be divided between messages. Fixing it requires to rethink encoders/decoders API.

@babca Can you verify if it solves the problem?