### PR TITLE
Unittest: Fix modem/edgeCases unit tests

### DIFF
--- a/test/test_modem.py
+++ b/test/test_modem.py
@@ -680,6 +680,7 @@ class TestEdgeCases(unittest.TestCase):
         global FAKE_MODEM            
         FAKE_MODEM = copy(fakemodems.GenericTestModem())
         FAKE_MODEM.responses['AT+CNMI=2,1,0,2\r'] = ['ERROR\r\n']
+        FAKE_MODEM.responses['AT+CNMI=2,1,0,1,0\r'] = ['ERROR\r\n']
         # This should pass without any problem, and AT+CNMI=2,1,0,2 should at least have been attempted during connect()
         cnmiWritten = [False]
         def writeCallbackFunc(data):


### PR DESCRIPTION
Fixes unit test for a SMS delivery reports.
Broken by @bennyslbs in 240d2f6 which provides different CNMI mode:
"Tries to configure CNMI to a SIM800L supported mode if original setting fails (could be done via checking supported modes)"
Unit test were not updated, so did not expect different ```AT_CNMI``` call.