### PR TITLE
Unittest: Fix supported commands unit test

### DIFF
--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -581,7 +581,10 @@ class GsmModem(SerialComms):
                     continue
 
             # Return found commands
-            return commands
+            if len(commands) == 0:
+                return None
+            else:
+                return commands
 
     @property
     def smsTextMode(self):

--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -609,6 +609,10 @@ class GsmModem(SerialComms):
         if self._commands == None:
             self._commands = self.supportedCommands
 
+        if self._commands == None:
+            self._smsSupportedEncodingNames = []
+            return self._smsSupportedEncodingNames
+
         if not '+CSCS' in self._commands:
             self._smsSupportedEncodingNames = []
             return self._smsSupportedEncodingNames
@@ -643,6 +647,9 @@ class GsmModem(SerialComms):
         if self._commands == None:
             self._commands = self.supportedCommands
 
+        if self._commands == None:
+            return self._smsEncoding
+
         if '+CSCS' in self._commands:
             response = self.write('AT+CSCS?')
 
@@ -667,6 +674,9 @@ class GsmModem(SerialComms):
         # Check if command is available
         if self._commands == None:
             self._commands = self.supportedCommands
+
+        if self._commands == None:
+            return False
 
         if not '+CSCS' in self._commands:
             return False

--- a/test/fakemodems.py
+++ b/test/fakemodems.py
@@ -99,7 +99,8 @@ class GenericTestModem(FakeModem):
                           'AT+WIND?\r': ['ERROR\r\n'],
                           'AT+WIND=50\r': ['ERROR\r\n'],
                           'AT+ZPAS?\r': ['ERROR\r\n'],
-                          'AT+CPIN?\r': ['+CPIN: READY\r\n', 'OK\r\n']} 
+                          'AT+CPIN?\r': ['+CPIN: READY\r\n', 'OK\r\n'],
+                          'AT\r': ['OK\r\n']}
 
     def getResponse(self, cmd):
         if not self._pinLock and cmd == 'AT+CLCC\r':

--- a/test/test_modem.py
+++ b/test/test_modem.py
@@ -195,6 +195,8 @@ class TestGsmModemGeneralApi(unittest.TestCase):
 
     def test_supportedCommands(self):
         def writeCallbackFunc(data):
+            if data == 'AT\r': # Handle keep-alive AT command
+                return
             self.assertEqual('AT+CLAC\r', data, 'Invalid data written to modem; expected "{0}", got: "{1}"'.format('AT+CLAC\r', data))
         self.modem.serial.writeCallbackFunc = writeCallbackFunc
         tests = ((['+CLAC:&C,D,E,\S,+CGMM,^DTMF\r\n', 'OK\r\n'], ['&C', 'D', 'E', '\S', '+CGMM', '^DTMF']),


### PR DESCRIPTION
Interactive command recognition, introduced inside b29a157 breaks supported commands unit test (test expects modem to give up after invalid ```AT+CLAC``` response)

Fixed by adding ```AT``` command inside fake modem, so device responds to this keep-alive request.
Additionally changes command recognition result to ```None``` in case of empty list for compatibility with previous behaviour.