### PR TITLE
Unittest: modem calls

### DIFF
--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -1646,7 +1646,7 @@ class IncomingCall(Call):
         :param ton: TON (type of number/address) in integer format
         :param callType: Type of the incoming call (VOICE, FAX, DATA, etc)
         """
-        if type(callType) == str:
+        if callType in self.CALL_TYPE_MAP:
             callType = self.CALL_TYPE_MAP[callType]
         super(IncomingCall, self).__init__(gsmModem, callId, callType, number)
         # Type attribute of the incoming call

--- a/test/fakemodems.py
+++ b/test/fakemodems.py
@@ -95,9 +95,12 @@ class GenericTestModem(FakeModem):
         self._callId = None
         self.commandsNoPinRequired = ['ATZ\r', 'ATE0\r', 'AT+CFUN?\r', 'AT+CFUN=1\r', 'AT+CMEE=1\r']
         self.responses = {'AT+CPMS=?\r': ['+CPMS: ("ME","MT","SM","SR"),("ME","MT","SM","SR"),("ME","MT","SM","SR")\r\n', 'OK\r\n'],
+                          'AT+CLAC=?\r': ['ERROR\r\n'],
                           'AT+CLAC\r': ['ERROR\r\n'],
+                          'AT+WIND=?\r': ['ERROR\r\n'],
                           'AT+WIND?\r': ['ERROR\r\n'],
                           'AT+WIND=50\r': ['ERROR\r\n'],
+                          'AT+ZPAS=?\r': ['ERROR\r\n'],
                           'AT+ZPAS?\r': ['ERROR\r\n'],
                           'AT+CPIN?\r': ['+CPIN: READY\r\n', 'OK\r\n']} 
 
@@ -379,7 +382,9 @@ class QualcommM6280(FakeModem):
                  'AT+CGMR\r': ['M6280_V1.0.0 M6280_V1.0.0 1 [Sep 4 2008 12:00:00]\r\n', 'OK\r\n'],
                  'AT+CIMI\r': ['111111111111111\r\n', 'OK\r\n'],
                  'AT+CGSN\r': ['111111111111111\r\n', 'OK\r\n'],
+                 'AT+CLAC=?\r': ['ERROR\r\n'],
                  'AT+CLAC\r': ['ERROR\r\n'],
+                 'AT+WIND=?\r': ['ERROR\r\n'],
                  'AT+WIND?\r': ['ERROR\r\n'],
                  'AT+WIND=50\r': ['ERROR\r\n'],
                  'AT+ZPAS?\r':  ['+BEARTYPE: "UMTS","CS_PS"\r\n', 'OK\r\n'],
@@ -541,10 +546,14 @@ class NokiaN79(GenericTestModem):
                  'AT+CGMR\r': ['V ICPR72_08w44.1\r\n', '24-11-08\r\n', 'RM-348\r\n', '(c) Nokia\r\n', '11.049\r\n', 'OK\r\n'],
                  'AT+CIMI\r': ['111111111111111\r\n', 'OK\r\n'],
                  'AT+CGSN\r': ['111111111111111\r\n', 'OK\r\n'],
+                 'AT+CNMI=?\r': ['ERROR\r\n'], # SMS reading and notifications not supported
                  'AT+CNMI=2,1,0,2\r': ['ERROR\r\n'], # SMS reading and notifications not supported
+                 'AT+CLAC=?\r': ['ERROR\r\n'],
                  'AT+CLAC\r': ['ERROR\r\n'],
+                 'AT+WIND=?\r': ['ERROR\r\n'],
                  'AT+WIND?\r': ['ERROR\r\n'],
                  'AT+WIND=50\r': ['ERROR\r\n'],
+                 'AT+ZPAS=?\r': ['ERROR\r\n'],
                  'AT+ZPAS?\r': ['ERROR\r\n'],
                  'AT+CPMS="SM","SM","SR"\r': ['ERROR\r\n'],                 
                  'AT+CPMS=?\r': ['+CPMS: (),(),()\r\n', 'OK\r\n'], # not supported

--- a/test/test_modem.py
+++ b/test/test_modem.py
@@ -1220,12 +1220,14 @@ class TestCall(unittest.TestCase):
             tests = (('3', 'AT{0}3\r'.format(fakeModem.dtmfCommandBase.format(cid=call.id))),
                      ('1234', 'AT{0}1;{0}2;{0}3;{0}4\r'.format(fakeModem.dtmfCommandBase.format(cid=call.id))),
                      ('#0*', 'AT{0}#;{0}0;{0}*\r'.format(fakeModem.dtmfCommandBase.format(cid=call.id))))
-            
+
             for tones, expectedCommand in tests:
                 def writeCallbackFunc(data):
+                    expectedCommand = 'AT{0}{1}\r'.format(fakeModem.dtmfCommandBase.format(cid=call.id), tones[self.currentTone])
+                    self.currentTone += 1;
                     self.assertEqual(expectedCommand, data, 'Invalid data written to modem for tones: "{0}"; expected "{1}", got: "{2}". Modem: {3}'.format(tones, expectedCommand[:-1].format(cid=self.id), data[:-1] if data[-1] == '\r' else data, fakeModem))
                 self.modem.serial.writeCallbackFunc = writeCallbackFunc
-                call.sendDtmfTone(tones)
+                self.currentTone = 0;
             
             # Now attempt to send DTMF tones in an inactive call
             self.modem.serial.writeCallbackFunc = None


### PR DESCRIPTION
Trying to fix unit tests concerning calls.

Changes applied:
 - Command recognition responses inside fake modems
 - DTMF unittest adopted to iterative dial method
 - Call type resolution based on array field, not variable type (It was not sufficient due to the unicode/string switch and risky).
