### PR TITLE
Unittest: python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ python:
   - "2.7"
 install:
   # Install unittest2 on Python 2.6
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors unittest2; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   # Install coveralls (for coveralls.io integration)
   - pip install coveralls
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
 script: python setup.py coverage
 after_success: coveralls

--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -1243,7 +1243,7 @@ class GsmModem(SerialComms):
                     # Re-enable extended format of incoming indication (optional)
                     self.write('AT+CRC=1')
                 except CommandError:
-                    self.log.warn('Extended incoming call indication format changed externally; unable to re-enable')
+                    self.log.warning('Extended incoming call indication format changed externally; unable to re-enable')
                     self._extendedIncomingCallIndication = False
         else:
             callType = None

--- a/gsmmodem/serial_comms.py
+++ b/gsmmodem/serial_comms.py
@@ -95,7 +95,7 @@ class SerialComms(object):
             rxBuffer = bytearray()
             while self.alive:
                 data = self.serial.read(1)
-                if data != b'': # check for timeout
+                if len(data) != 0: # check for timeout
                     #print >> sys.stderr, ' RX:', data,'({0})'.format(ord(data))
                     rxBuffer.append(ord(data))
                     if rxBuffer[-readTermLen:] == readTermSeq:

--- a/test/fakemodems.py
+++ b/test/fakemodems.py
@@ -21,6 +21,9 @@ class FakeModem(object):
         self.dtmfCommandBase = '+VTS='
 
     def getResponse(self, cmd):
+        if type(cmd) == bytes:
+            cmd = cmd.decode()
+
         if self.deviceBusyErrorCounter > 0:
             self.deviceBusyErrorCounter -= 1
             return ['+CME ERROR: 515\r\n']
@@ -107,6 +110,9 @@ class GenericTestModem(FakeModem):
                           'AT\r': ['OK\r\n']}
 
     def getResponse(self, cmd):
+        if type(cmd) == bytes:
+            cmd = cmd.decode()
+
         if not self._pinLock and cmd == 'AT+CLCC\r':
             if self._callNumber:
                 if self._callState == 0:
@@ -171,6 +177,9 @@ class WavecomMultiband900E1800(FakeModem):
         self.commandsNoPinRequired = ['ATZ\r', 'ATE0\r', 'AT+CFUN?\r', 'AT+CFUN=1\r', 'AT+CMEE=1\r']
 
     def getResponse(self, cmd):
+        if type(cmd) == bytes:
+            cmd = cmd.decode()
+
         if cmd == 'AT+CFUN=1\r':
             self.deviceBusyErrorCounter = 2 # This modem takes quite a while to recover from this
             return ['OK\r\n']
@@ -338,6 +347,9 @@ class HuaweiE1752(FakeModem):
         self.dtmfCommandBase = '^DTMF={cid},'
 
     def getResponse(self, cmd):
+        if type(cmd) == bytes:
+            cmd = cmd.decode()
+
         # Device defaults to ^USSDMODE == 1
         if cmd.startswith('AT+CUSD=1') and self._ussdMode == 1:
             return ['ERROR\r\n']
@@ -395,6 +407,9 @@ class QualcommM6280(FakeModem):
                  'AT+CPIN?\r': ['+CPIN: READY\r\n', 'OK\r\n']}
 
     def getResponse(self, cmd):
+        if type(cmd) == bytes:
+            cmd = cmd.decode()
+
         if not self._pinLock:
             if cmd.startswith('AT+CSMP='):
                 # Clear the SMSC number (this behaviour was reported in issue #8 on github)
@@ -486,6 +501,9 @@ class ZteK3565Z(FakeModem):
                  'AT+CPIN?\r': ['+CPIN: READY\r\n', 'OK\r\n']}
 
     def getResponse(self, cmd):
+        if type(cmd) == bytes:
+            cmd = cmd.decode()
+
         if not self._pinLock:
             if cmd.startswith('AT+CSMP='):
                 # Clear the SMSC number (this behaviour was reported in issue #8 on github)

--- a/test/test_modem.py
+++ b/test/test_modem.py
@@ -101,6 +101,8 @@ class MockSerialPackage(object):
                 
         def write(self, data):            
             if self.writeCallbackFunc != None:
+                if type(data) == bytes:
+                    data = data.decode()
                 self.writeCallbackFunc(data)
             self.writeQueue.append(data)
             


### PR DESCRIPTION
Trying to make fix unit tests for python3*:
 - Force old unit tests to convert ``bytes`` into ``string``, due to the fact that current implementation uses bytes as interface for serial communication.
 - Statement ``if data != b''`` is sensitive whether data type is ``string`` or ``bytes`` 
 - Remove deprecated ``--use-mirrors`` flag from pip commands (since 7.0.0 see: https://pip.pypa.io/en/stable/news)