### PR TITLE
Handle invalid timezone values

### DIFF
--- a/gsmmodem/pdu.py
+++ b/gsmmodem/pdu.py
@@ -73,12 +73,12 @@ class SmsPduTzInfo(tzinfo):
         #  - Read HEX value as decimal
         #  - Multiply by 15
         # See: https://en.wikipedia.org/wiki/GSM_03.40#Time_Format
-        try:
-            tzOffsetMinutes = int('{0:0>2X}'.format(tzHexVal & 0x7F)) * 15
-        except:
-            # Possible fix for #15
-            tzHexVal = int((tzHexVal & 0x0F) * 0x10) + int((tzHexVal & 0x0F) / 0x10)
-            tzOffsetMinutes = int('{0:0>2X}'.format(tzHexVal & 0x7F)) * 15
+
+        # Possible fix for #15 - convert invalid character to BCD-value
+        if (tzHexVal & 0x0F) > 0x9:
+            tzHexVal +=0x06
+
+        tzOffsetMinutes = int('{0:0>2X}'.format(tzHexVal & 0x7F)) * 15
 
         if tzHexVal & 0x80 == 0: # positive
             self._offset = timedelta(minutes=(tzOffsetMinutes))

--- a/test/test_modem.py
+++ b/test/test_modem.py
@@ -2072,31 +2072,48 @@ class TestSmsStatusReports(unittest.TestCase):
                 time.sleep(0.1)
         self.modem.close()
 
-    def test_receiveSmsPduMode_zeroLengthSmscAndHugeTimeZoneValue(self):
+    def test_receiveSmsPduMode_invalidPDUsRecordedFromModems(self):
         """ Test receiving PDU-mode SMS using data captured from failed operations/bug reports """
-        modemResponse = ['+CMGR: 1,,26\r\n', '0006230E9126983575169498610103409544C26101034095448200\r\n', 'OK\r\n']
+        tests = ((['+CMGR: 1,,26\r\n', '0006230E9126983575169498610103409544C26101034095448200\r\n', 'OK\r\n'], # see: babca/python-gsmmodem#15
+                  Sms.STATUS_RECEIVED_READ, # message read status
+                  '+62895357614989', # number
+                  35, # reference
+                  datetime(2016, 10, 30, 4, 59, 44, tzinfo=SimpleOffsetTzInfo(8)), # sentTime
+                  datetime(2016, 10, 30, 4, 59, 44, tzinfo=SimpleOffsetTzInfo(7)), # deliverTime
+                  StatusReport.DELIVERED), # delivery status
+                 )
 
-        callbackInfo = [False, '', '', -1, None, '', None]
-        def smsCallbackFunc1(sms):
-            try:
-                self.assertIsInstance(sms, gsmmodem.modem.StatusReport)
-                self.assertEqual(sms.status, gsmmodem.modem.Sms.STATUS_RECEIVED_READ)
-            finally:
-                callbackInfo[0] = True
+        callbackDone = [False]
 
-        def writeCallback1(data):
-            if data.startswith('AT+CMGR'):
-                self.modem.serial.flushResponseSequence = True
-                self.modem.serial.responseSequence = modemResponse
+        for modemResponse, msgStatus, number, reference, sentTime, deliverTime, deliveryStatus in tests:
+            def smsCallbackFunc1(sms):
+                try:
+                    self.assertIsInstance(sms, gsmmodem.modem.StatusReport)
+                    self.assertEqual(sms.status, msgStatus, 'Status report read status incorrect. Expected: "{0}", got: "{1}"'.format(msgStatus, sms.status))
+                    self.assertEqual(sms.number, number, 'SMS sender number incorrect. Expected: "{0}", got: "{1}"'.format(number, sms.number))
+                    self.assertEqual(sms.reference, reference, 'Status report SMS reference number incorrect. Expected: "{0}", got: "{1}"'.format(reference, sms.reference))
+                    self.assertIsInstance(sms.timeSent, datetime, 'SMS sent time type invalid. Expected: datetime.datetime, got: {0}"'.format(type(sms.timeSent)))
+                    self.assertEqual(sms.timeSent, sentTime, 'SMS sent time incorrect. Expected: "{0}", got: "{1}"'.format(sentTime, sms.timeSent))
+                    self.assertIsInstance(sms.timeFinalized, datetime, 'SMS finalized time type invalid. Expected: datetime.datetime, got: {0}"'.format(type(sms.timeFinalized)))
+                    self.assertEqual(sms.timeFinalized, deliverTime, 'SMS finalized time incorrect. Expected: "{0}", got: "{1}"'.format(deliverTime, sms.timeFinalized))
+                    self.assertEqual(sms.deliveryStatus, deliveryStatus, 'SMS delivery status incorrect. Expected: "{0}", got: "{1}"'.format(deliveryStatus, sms.deliveryStatus))
+                    self.assertEqual(sms.smsc, None, 'This SMS should not have any SMSC information')
+                finally:
+                    callbackDone[0] = True
 
-        self.initModem(smsStatusReportCallback=smsCallbackFunc1)
-        # Fake a "new message" notification
-        self.modem.serial.writeCallbackFunc = writeCallback1
-        self.modem.serial.flushResponseSequence = True
-        self.modem.serial.responseSequence = ['+CDSI: "SM",1\r\n']
-        # Wait for the handler function to finish
-        while callbackInfo[0] == False:
-            time.sleep(0.1)
+            def writeCallback1(data):
+                if data.startswith('AT+CMGR'):
+                    self.modem.serial.flushResponseSequence = True
+                    self.modem.serial.responseSequence = modemResponse
+
+            self.initModem(smsStatusReportCallback=smsCallbackFunc1)
+            # Fake a "new message" notification
+            self.modem.serial.writeCallbackFunc = writeCallback1
+            self.modem.serial.flushResponseSequence = True
+            self.modem.serial.responseSequence = ['+CDSI: "SM",1\r\n']
+            # Wait for the handler function to finish
+            while callbackDone[0] == False:
+                time.sleep(0.1)
 
 
 


### PR DESCRIPTION
Possible fix for #15 
Returned timezone value is not a valid BCD number (0x2C). The timezone value should be close to +7 (+28 quarters, 0x28 in BCD). Currently I can see four interpretations:
 - not masked, badly positioned sign bit: 0x2C & 0x77 = 0x24 (+6 h)
 - badly positioned sign bit: 0x2C = -0x24 (-6 h)
 - not reorganized bytes: 0x2C -> 0xC2 = -0x42 (-10.5 h)
 - overloaded BCD value: 0x2C + 0x6 = 0x32 (+8h)

According to the fact that the SMS was send from Jakarta (+7), negative values are (most probably) invalid (option 2 and 3).
Indonesia has timezones +7, +8 and +9, so 4th option is more probable that the 1st one (why local message should leave the country?).

This PR changes timezone calculation using 4th option and redefines unit test, which has problematic status PDU.