### PR TITLE
HUAWEI CEND notification format fix

### DIFF
--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -291,7 +291,7 @@ class GsmModem(SerialComms):
             self.log.info('Loading Huawei call state update table')
             self._callStatusUpdates = ((re.compile('^\^ORIG:(\d),(\d)$'), self._handleCallInitiated),
                                        (re.compile('^\^CONN:(\d),(\d)$'), self._handleCallAnswered),
-                                       (re.compile('^\^CEND:(\d),(\d),(\d)+,(\d)+$'), self._handleCallEnded))
+                                       (re.compile('^\^CEND:(\d),(\d+),(\d)+,(\d)+$'), self._handleCallEnded))
             self._mustPollCallStatus = False
             # Huawei modems use ^DTMF to send DTMF tones; use that instead
             Call.DTMF_COMMAND_BASE = '^DTMF={cid},'


### PR DESCRIPTION
It seems that `^CEND` notification on Huawei modems has format `^CEND:<call_index>,<duration>,<end_status>,<cc_cause>` . Thus old regex `'^\^CEND:(\d),(\d),(\d)+,(\d)+$'` fails then call duration is more that 9 sec.