### PR TITLE
Fix supportedCommands property for Teleofis modems

### DIFF
--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -9,7 +9,7 @@ from time import sleep
 from .serial_comms import SerialComms
 from .exceptions import CommandError, InvalidStateException, CmeError, CmsError, InterruptedException, TimeoutException, PinRequiredError, IncorrectPinError, SmscNumberUnknownError
 from .pdu import encodeSmsSubmitPdu, decodeSmsPdu, encodeGsm7, encodeTextMode
-from .util import SimpleOffsetTzInfo, lineStartingWith, allLinesMatchingPattern, parseTextModeTimeStr
+from .util import SimpleOffsetTzInfo, lineStartingWith, allLinesMatchingPattern, parseTextModeTimeStr, removeAtPrefix
 
 #from . import compat # For Python 2.6 compatibility
 from gsmmodem.util import lineMatching
@@ -554,7 +554,7 @@ class GsmModem(SerialComms):
                     commands = commands[6:] # remove the +CLAC: prefix before splitting
                 return commands.split(',')
             elif len(response) > 2: # Multi-line response
-                return [cmd.strip() for cmd in response[:-1]]
+                return [removeAtPrefix(cmd.strip()) for cmd in response[:-1]]
             else:
                 self.log.debug('Unhandled +CLAC response: {0}'.format(response))
                 return None

--- a/gsmmodem/util.py
+++ b/gsmmodem/util.py
@@ -108,3 +108,17 @@ def allLinesMatchingPattern(pattern, lines):
         if m:
             result.append(m)
     return result
+
+
+def removeAtPrefix(string):
+    """ Remove AT prefix from a specified string.
+
+    :param string: An original string
+    :type string: str
+
+    :return: A string with AT prefix removed
+    :rtype: str
+    """
+    if string.startswith('AT'):
+        return string[2:]
+    return string

--- a/test/test_modem.py
+++ b/test/test_modem.py
@@ -207,7 +207,7 @@ class TestGsmModemGeneralApi(unittest.TestCase):
                  (['FGH,RTY,UIO\r\n', 'OK\r\n'], ['FGH', 'RTY', 'UIO']), # nasty, but possible
                  # ZTE-like response: do not start with +CLAC, and use multiple lines
                  (['A\r\n', 'BCD\r\n', 'EFGH\r\n', 'OK\r\n'], ['A', 'BCD', 'EFGH']),
-                 # Siemens response: like ZTE but each command has AT prefix
+                 # Teleofis response: like ZTE but each command has AT prefix
                  (['AT&F\r\n', 'AT&V\r\n', 'AT&W\r\n', 'AT+CACM\r\n', 'OK\r\n'], ['&F', '&V', '&W', '+CACM']),
                  # Some Huawei modems have a ZTE-like response, but add an addition \r character at the end of each listed command
                  (['Q\r\r\n', 'QWERTY\r\r\n', '^DTMF\r\r\n', 'OK\r\n'], ['Q', 'QWERTY', '^DTMF']))

--- a/test/test_modem.py
+++ b/test/test_modem.py
@@ -207,6 +207,8 @@ class TestGsmModemGeneralApi(unittest.TestCase):
                  (['FGH,RTY,UIO\r\n', 'OK\r\n'], ['FGH', 'RTY', 'UIO']), # nasty, but possible
                  # ZTE-like response: do not start with +CLAC, and use multiple lines
                  (['A\r\n', 'BCD\r\n', 'EFGH\r\n', 'OK\r\n'], ['A', 'BCD', 'EFGH']),
+                 # Siemens response: like ZTE but each command has AT prefix
+                 (['AT&F\r\n', 'AT&V\r\n', 'AT&W\r\n', 'AT+CACM\r\n', 'OK\r\n'], ['&F', '&V', '&W', '+CACM']),
                  # Some Huawei modems have a ZTE-like response, but add an addition \r character at the end of each listed command
                  (['Q\r\r\n', 'QWERTY\r\r\n', '^DTMF\r\r\n', 'OK\r\n'], ['Q', 'QWERTY', '^DTMF']))
         for responseSequence, expected in tests:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -75,6 +75,7 @@ class TestUtil(unittest.TestCase):
             self.assertIsInstance(tz.__repr__(), str)
 
     def test_removeAtPrefix(self):
+        """ Tests function: removeAtPrefix"""
         tests = (('AT+CLAC', '+CLAC'), ('ATZ', 'Z'), ('+CLAC', '+CLAC'), ('Z', 'Z'))
         for src, dst in tests:
             res = removeAtPrefix(src)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 
 from . import compat # For Python 2.6 compatibility
 
-from gsmmodem.util import allLinesMatchingPattern, lineMatching, lineStartingWith, lineMatchingPattern, SimpleOffsetTzInfo
+from gsmmodem.util import allLinesMatchingPattern, lineMatching, lineStartingWith, lineMatchingPattern, SimpleOffsetTzInfo, removeAtPrefix
 
 class TestUtil(unittest.TestCase):
     """ Tests misc utilities from gsmmodem.util """
@@ -73,6 +73,12 @@ class TestUtil(unittest.TestCase):
             self.assertEqual(tz.utcoffset(None), timedelta(hours=hours))
             self.assertEqual(tz.dst(None), timedelta(0))
             self.assertIsInstance(tz.__repr__(), str)
+
+    def test_removeAtPrefix(self):
+        tests = (('AT+CLAC', '+CLAC'), ('ATZ', 'Z'), ('+CLAC', '+CLAC'), ('Z', 'Z'))
+        for src, dst in tests:
+            res = removeAtPrefix(src)
+            self.assertEqual(res, dst)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some modems like ~~Siemens~~ Teleofis have different `AT+CLAC` command response:
```                                                                
ATA                                                                      
ATD                                                                      
ATH                                                                      
ATO                                                                      
ATE                                                                      
ATI
...
AT+CECALL
AT+CCED
AT+CSVM

OK
```

So we need to remove `AT` prefix to return valid supportedCommands value. 