### PR TITLE
Add long sms concat info for received sms

### DIFF
--- a/examples/sms_handler_demo.py
+++ b/examples/sms_handler_demo.py
@@ -18,7 +18,9 @@ PIN = None # SIM card PIN (if any)
 from gsmmodem.modem import GsmModem
 
 def handleSms(sms):
-    print(u'== SMS message received ==\nFrom: {0}\nTime: {1}\nMessage:\n{2}\n'.format(sms.number, sms.time, sms.text))
+    # long sms Concatenation support: reference, parts, number
+    concat = sms.concat.__dict__ if sms.concat else {}
+    print(u'== SMS message received ==\nFrom: {0}\nTime: {1}\nconcat: {2}\nMessage:\n{3}\n'.format(sms.number, sms.time, concat, sms.text))
     print('Replying to SMS...')
     sms.reply(u'SMS received: "{0}{1}"'.format(sms.text[:20], '...' if len(sms.text) > 20 else ''))
     print('SMS sent.\n')


### PR DESCRIPTION
COPY from https://github.com/faucamp/python-gsmmodem/pull/93

--------------------

Add `concat` property for `ReceivedSms`:
  - Get Concantion from pdu `smsDict['udh']`
  - Update `examples/sms_handler_demo.py`

test output of sms_handler_demo.py

```
== SMS message received ==
From: +8613400000000
Time: 2018-04-13 20:00:02+08:00
concat: {}
Message:
hello, no concat

== SMS message received ==
From: +8613400000000
Time: 2018-04-13 20:00:08+08:00
concat: {'reference': 21, 'number': 2, 'parts': 2, 'dataLength': 3, 'data': [21, 2, 2], 'id': 0}
Message:
test mesage, part 2 of 2
```