### PR TITLE
Allow user to set (RTS/CTS) and (DSR/DTR) flows control

### DIFF
--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -147,8 +147,8 @@ class GsmModem(SerialComms):
     CDSI_REGEX = re.compile('\+CDSI:\s*"([^"]+)",(\d+)$')
     CDS_REGEX  = re.compile('\+CDS:\s*([0-9]+)"$')
 
-    def __init__(self, port, baudrate=115200, incomingCallCallbackFunc=None, smsReceivedCallbackFunc=None, smsStatusReportCallback=None, requestDelivery=True, AT_CNMI="", *a, **kw):
-        super(GsmModem, self).__init__(port, baudrate, notifyCallbackFunc=self._handleModemNotification, *a, **kw)
+    def __init__(self, port, baudrate=115200, rtscts=True, dsrdtr=True, incomingCallCallbackFunc=None, smsReceivedCallbackFunc=None, smsStatusReportCallback=None, requestDelivery=True, AT_CNMI="", *a, **kw):
+        super(GsmModem, self).__init__(port, baudrate, rtscts, dsrdtr, notifyCallbackFunc=self._handleModemNotification, *a, **kw)
         self.incomingCallCallback = incomingCallCallbackFunc or self._placeholderCallback
         self.smsReceivedCallback = smsReceivedCallbackFunc or self._placeholderCallback
         self.smsStatusReportCallback = smsStatusReportCallback or self._placeholderCallback

--- a/gsmmodem/serial_comms.py
+++ b/gsmmodem/serial_comms.py
@@ -22,7 +22,7 @@ class SerialComms(object):
     # Default timeout for serial port reads (in seconds)
     timeout = 1
 
-    def __init__(self, port, baudrate=115200, notifyCallbackFunc=None, fatalErrorCallbackFunc=None, *args, **kwargs):
+    def __init__(self, port, baudrate=115200, rtscts=True, dsrdtr=True, notifyCallbackFunc=None, fatalErrorCallbackFunc=None, *args, **kwargs):
         """ Constructor
 
         :param fatalErrorCallbackFunc: function to call if a fatal error occurs in the serial device reading thread
@@ -31,6 +31,8 @@ class SerialComms(object):
         self.alive = False
         self.port = port
         self.baudrate = baudrate
+        self.dsrdtr = dsrdtr
+        self.rtscts = rtscts
 
         self._responseEvent = None # threading.Event()
         self._expectResponseTermSeq = None # expected response terminator sequence
@@ -47,7 +49,7 @@ class SerialComms(object):
 
     def connect(self):
         """ Connects to the device and starts the read thread """
-        self.serial = serial.Serial(dsrdtr=True, rtscts=True, port=self.port, baudrate=self.baudrate,
+        self.serial = serial.Serial(rtscts=self.rtscts, dsrdtr=self.dsrdtr, port=self.port, baudrate=self.baudrate,
                                     timeout=self.timeout,*self.com_args,**self.com_kwargs)
         # Start read thread
         self.alive = True


### PR DESCRIPTION
I've tried `python-gsmmodem` with SIMCOM SIM300 based modem ([ОВЕН ПМ01](https://www.owen.ru/product/pm01)), it needs (RTS/CTS) and (DSR/DTR) set `False`.