### PR TITLE
Fix timeout value on reader thread wait in SMS send example

### DIFF
--- a/examples/sms_handler_demo.py
+++ b/examples/sms_handler_demo.py
@@ -32,7 +32,7 @@ def main():
     modem.connect(PIN)
     print('Waiting for SMS message...')
     try:
-        modem.rxThread.join(2**31) # Specify a (huge) timeout so that it essentially blocks indefinitely, but still receives CTRL+C interrupt signal
+        modem.rxThread.join() # Main thread essentially blocks indefinitely, but still receives CTRL+C interrupt signal
     finally:
         modem.close()
 


### PR DESCRIPTION
timeout value of 2**31 in join was returning immediately on Raspberry Pi