### PR TITLE
fix: AT+FUNC answer with 2 parameters

### DIFF
--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -221,7 +221,8 @@ class GsmModem(SerialComms):
             pinCheckComplete = False
         self.write('ATE0') # echo off
         try:
-            cfun = int(lineStartingWith('+CFUN:', self.write('AT+CFUN?'))[7:]) # example response: +CFUN: 1
+            cfun = lineStartingWith('+CFUN:', self.write('AT+CFUN?'))[7:] # example response: +CFUN: 1 ou +CFUN: 1,0
+            cfun = int(cfun.split(",")[0])
             if cfun != 1:
                 self.write('AT+CFUN=1')
         except CommandError:

--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -221,7 +221,7 @@ class GsmModem(SerialComms):
             pinCheckComplete = False
         self.write('ATE0') # echo off
         try:
-            cfun = lineStartingWith('+CFUN:', self.write('AT+CFUN?'))[7:] # example response: +CFUN: 1 ou +CFUN: 1,0
+            cfun = lineStartingWith('+CFUN:', self.write('AT+CFUN?'))[7:] # example response: +CFUN: 1 or +CFUN: 1,0
             cfun = int(cfun.split(",")[0])
             if cfun != 1:
                 self.write('AT+CFUN=1')


### PR DESCRIPTION
BGS5 has 2 parameters for AT+FUNC : <power_mode> , <STK_mode>

<STK_mode> is not very useful, just ignore it.
