### PR TITLE
Correct PDU Decoding Error

### DIFF
--- a/gsmmodem/pdu.py
+++ b/gsmmodem/pdu.py
@@ -465,8 +465,11 @@ def _decodeUserData(byteIter, userDataLen, dataCoding, udhPresent):
             # Since we are using 7-bit data, "fill bits" may have been added to make the UDH end on a septet boundary
             shift = ((udhLen + 1) * 8) % 7 # "fill bits" needed to make the UDH end on a septet boundary
             # Simulate another "shift" in the unpackSeptets algorithm in order to ignore the fill bits
-            prevOctet = next(byteIter)
-            shift += 1
+            if shift:
+                prevOctet = next(byteIter)
+                shift += 1
+            else:
+                prevOctet = 0
 
     if dataCoding == 0x00: # GSM-7
         if udhPresent:


### PR DESCRIPTION
* `gsmmodem/pdu.py.Pdu._decodeUserData ()` now correctly decodes segmented SMS messages.  See [PDU Decoding ERROR](https://github.com/babca/python-gsmmodem/issues/99).
