### PR TITLE
Fix SyntaxWarning: "is" and "is not" with a literal

### DIFF
--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -797,13 +797,13 @@ class GsmModem(SerialComms):
                 response = self.write('AT+CPBS?')
                 selected_phonebook = response[0][6:].split('"')[1] # first line, remove the +CSCS: prefix, split, first parameter
 
-                if selected_phonebook is not "ON":
+                if selected_phonebook != "ON":
                     self.write('AT+CPBS="ON"')
 
                 response = self.write("AT+CPBR=1")
                 self.write('AT+CPBS="{0}"'.format(selected_phonebook))
 
-            if response is "OK": # command is supported, but no number is set
+            if response == "OK": # command is supported, but no number is set
                 return None
             elif len(response) == 2: # OK and phone number. Actual number is in the first line, second parameter, and is placed inside quotation marks
                 cnumLine = response[0]
@@ -823,7 +823,7 @@ class GsmModem(SerialComms):
     @ownNumber.setter
     def ownNumber(self, phone_number):
         actual_phonebook = self.write('AT+CPBS?')
-        if actual_phonebook is not "ON":
+        if actual_phonebook != "ON":
             self.write('AT+CPBS="ON"')
         self.write('AT+CPBW=1,"' + phone_number + '"')
 


### PR DESCRIPTION
While adding support to a new modem I noticed the following warning:
   /usr/local/lib/python3.10/site-packages/gsmmodem/modem.py:835: SyntaxWarning: "is not" with a literal. Did you mean "!="?
     if selected_phonebook is not "ON":
   /usr/local/lib/python3.10/site-packages/gsmmodem/modem.py:841: SyntaxWarning: "is" with a literal. Did you mean "=="?
     if response is "OK": # command is supported, but no number is set
   /usr/local/lib/python3.10/site-packages/gsmmodem/modem.py:861: SyntaxWarning: "is not" with a literal. Did you mean "!="?
     if actual_phonebook is not "ON":

This patch makes the changes from "is not" to != and from "is" to "==".

Signed-off-by: Peter Senna Tschudin <peter.senna@spearline.com>