### PR TITLE
Use serial.serial_for_url() to allow usage of RFC2217 serial ports

### DIFF
--- a/gsmmodem/serial_comms.py
+++ b/gsmmodem/serial_comms.py
@@ -47,8 +47,8 @@ class SerialComms(object):
 
     def connect(self):
         """ Connects to the device and starts the read thread """
-        self.serial = serial.Serial(dsrdtr=True, rtscts=True, port=self.port, baudrate=self.baudrate,
-                                    timeout=self.timeout,*self.com_args,**self.com_kwargs)
+        self.serial = serial.serial_for_url(dsrdtr=True, rtscts=True, url=self.port, baudrate=self.baudrate,
+                                            timeout=self.timeout, *self.com_args, **self.com_kwargs)
         # Start read thread
         self.alive = True
         self.rxThread = threading.Thread(target=self._readLoop)


### PR DESCRIPTION
Proposed solution for https://github.com/babca/python-gsmmodem/issues/113

According to the [documentation](https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.serial_for_url) method `serial.serial_for_url()` may be used to allow for local and remote serial connections.