### PR TITLE
Add options to configure serial flow control

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install pypa/build
@@ -32,7 +32,7 @@ jobs:
         run: |
           python -m build
       - name: Upload dist files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: dist-files
           path: dist/
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download dist files
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist-files
           path: dist/
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download dist files
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist-files
           path: dist/

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-python-gsmmodem-new
-===================
+python-gsmmodem-2025
+====================
 *GSM modem module for Python*
 
 python-gsmmodem is a module that allows easy control of a GSM modem attached
@@ -28,6 +28,12 @@ Bundled utilities:
 - **identify-modem.py**: simple utility to identify attached modem. Can also be
   used to provide debug information used for development of python-gsmmodem. 
 
+How is this different than https://github.com/babca/python-gsmmodem?
+--------------------------------------------------------------------
+It seems the `python-gsmmodem-new` repository is not maintained anymore. 
+This fork is a copy of the last commit from the original repository, with some modifications.
+Specifically, I started this to handle SIM800 modem, which require xonxoff flow control to work properly.
+
 How to use this package
 -----------------------
 
@@ -44,32 +50,32 @@ Requirements
 How to install this package
 ---------------------------
 
-There are multiple ways to install ``python-gsmmodem-new`` package:
+There are multiple ways to install ``python-gsmmodem-2025`` package:
 
 Automatic installation of the latest "stable" release from PyPI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
-    pip install python-gsmmodem-new
+    pip install python-gsmmodem-2025
 
 `pip <http://www.pip-installer.org>`_ will automatically download and install
 all dependencies, as required. You can also utilise ``easy_install`` in the
 same manner as using ``pip`` above.  
 
-If you are utilising ``python-gsmmodem-new`` as part of another project,
+If you are utilising ``python-gsmmodem-2025`` as part of another project,
 add it to your ``install_requires`` section of your ``setup.py`` file and
 upon your project's installation, it will be pulled in automatically.
 
 Manual installation of the latest "stable" release from PyPI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Download a ``python-gsmmodem-new`` archive from `PyPI
-<https://pypi.python.org/pypi/python-gsmmodem-new>`_, extract it and install the package with command::
+Download a ``python-gsmmodem-2025`` archive from `PyPI
+<https://pypi.python.org/pypi/python-gsmmodem-2025>`_, extract it and install the package with command::
 
     python setup.py install
 
-Note that ``python-gsmmodem-new`` package relies on ``pySerial`` for serial communications: 
+Note that ``python-gsmmodem-2025`` package relies on ``pySerial`` for serial communications: 
 https://github.com/pyserial/pyserial
 
 Installation of the latest commit from GitHub
@@ -81,7 +87,7 @@ Clone from GitHub::
     cd python-gsmmodem/
     python setup.py install
 
-Note that ``python-gsmmodem-new`` package relies on ``pySerial`` for serial communications: 
+Note that ``python-gsmmodem-2025`` package relies on ``pySerial`` for serial communications: 
 https://github.com/pyserial/pyserial
 
 Testing the package

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 python-gsmmodem-2025
 ====================
-*GSM modem module for Python*
+*GSM modem module for Python forked in 2025*
 
 python-gsmmodem is a module that allows easy control of a GSM modem attached
 to the system. It also includes a couple of useful commandline utilities for

--- a/gsmmodem/serial_comms.py
+++ b/gsmmodem/serial_comms.py
@@ -22,7 +22,8 @@ class SerialComms(object):
     # Default timeout for serial port reads (in seconds)
     timeout = 1
 
-    def __init__(self, port, baudrate=115200, notifyCallbackFunc=None, fatalErrorCallbackFunc=None, *args, **kwargs):
+    def __init__(self, port, baudrate=115200, notifyCallbackFunc=None, fatalErrorCallbackFunc=None, 
+                xonxoff=False, dsrdtr=True, rtscts=True, *args, **kwargs):
         """ Constructor
 
         :param fatalErrorCallbackFunc: function to call if a fatal error occurs in the serial device reading thread
@@ -31,6 +32,10 @@ class SerialComms(object):
         self.alive = False
         self.port = port
         self.baudrate = baudrate
+
+        self.xonxoff = xonxoff
+        self.dsrdtr = dsrdtr
+        self.rtscts = rtscts
 
         self._responseEvent = None # threading.Event()
         self._expectResponseTermSeq = None # expected response terminator sequence
@@ -47,7 +52,7 @@ class SerialComms(object):
 
     def connect(self):
         """ Connects to the device and starts the read thread """
-        self.serial = serial.Serial(dsrdtr=True, rtscts=True, port=self.port, baudrate=self.baudrate,
+        self.serial = serial.Serial(xonxoff=self.xonxoff, dsrdtr=self.dsrdtr, rtscts=self.rtscts, port=self.port, baudrate=self.baudrate,
                                     timeout=self.timeout,*self.com_args,**self.com_kwargs)
         # Start read thread
         self.alive = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
-name = python-gsmmodem-new
+name = python-gsmmodem-2025
 description = Control an attached GSM modem: send/receive SMS messages, handle calls, etc
 license = LGPLv3+
 author = Francois Aucamp
 author_email = francois.aucamp@gmail.com
-url = https://github.com/babca/python-gsmmodem
+url = https://github.com/jaydenpung/python-gsmmodem
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 classifiers =


### PR DESCRIPTION
I encountered an issue when using this library for SIM800. When connecting with putty it works but not with the library. It appears putty default the serial flow control to xonxoff
![image](https://github.com/user-attachments/assets/4ba8102a-42bd-4baf-a5f9-b7e55a72b2a0)

When we set up the serial, we need to set the `xonxoff` to true and `rtscts`, `dsrstr` to false. This PR change would allow you to use it like this:

```
from gsmmodem.modem import GsmModem

# set flow control to xonxoff for modem like SIMCOM SIM800
modem = GsmModem(port, 9600, xonxoff=True, rtscts=False, dsrdtr=False)
```

This is a known issue and had been raised before:
https://github.com/babca/python-gsmmodem/issues/102
https://github.com/babca/python-gsmmodem/issues/94

I suspect this repo is no longer maintained. For anyone interested, I have published to pypi and you can use them:
```
pip install python-gsmmodem-2025
```
or add to requirements.txt
```
python-gsmmodem-2025
```